### PR TITLE
Don't disable default features of `form_urlencoded`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ include = ["src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 readme = "README.md"
 
 [dependencies]
-form_urlencoded = { version = "1.0", default-features = false }
+form_urlencoded = "1.0"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
In https://github.com/servo/rust-url/pull/722, we would like to make the crate potentially not need `alloc` in the future, but to do so, we must now introduce a required `alloc` feature.

Since this crate uses `default-features = false` on `form_urlencoded` (which previously did nothing), it will break once that change lands.